### PR TITLE
Refactor(branches, user, generic products and promos): migrate CRUD to SDK types and remove local interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@pharmatech/sdk": "^0.4.8",

--- a/src/app/(dashboard)/branches/[id]/page.tsx
+++ b/src/app/(dashboard)/branches/[id]/page.tsx
@@ -10,28 +10,14 @@ import { api } from '@/lib/sdkConfig';
 import { toast } from 'react-toastify';
 import { REDIRECTION_TIMEOUT } from '@/lib/utils/contants';
 import { useAuth } from '@/context/AuthContext';
-
-interface BranchItem {
-  id: string;
-  name: string;
-  address: string;
-  city: {
-    id: string;
-    name: string;
-    state: {
-      name: string;
-    };
-  };
-  latitude: number;
-  longitude: number;
-}
+import { BranchResponse } from '@pharmatech/sdk';
 
 export default function BranchDetailsPage() {
   const params = useParams();
   const { token } = useAuth();
   const id = params?.id && typeof params.id === 'string' ? params.id : '';
   const router = useRouter();
-  const [branch, setBranch] = useState<BranchItem | null>(null);
+  const [branch, setBranch] = useState<BranchResponse | null>(null);
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {

--- a/src/app/(dashboard)/branches/new/page.tsx
+++ b/src/app/(dashboard)/branches/new/page.tsx
@@ -8,16 +8,10 @@ import { newBranchSchema } from '@/lib/validations/newBranchSchema';
 import { api } from '@/lib/sdkConfig';
 import Dropdown from '@/components/Dropdown';
 import { toast } from 'react-toastify';
+import { StateResponse, CityResponse } from '@pharmatech/sdk';
 
-interface StateItem {
-  id: string;
-  name: string;
-}
-
-interface CityItem {
-  id: string;
-  name: string;
-}
+/// This is a constant that represents the ID of Venezuela.
+const COUNTRY_ID = '1238bc2a-45a5-47e4-9cc1-68d573089ca1';
 
 export default function NewBranchPage() {
   const [name, setName] = useState('');
@@ -25,8 +19,8 @@ export default function NewBranchPage() {
   const [latitude, setLatitude] = useState('');
   const [longitude, setLongitude] = useState('');
 
-  const [states, setStates] = useState<StateItem[]>([]);
-  const [cities, setCities] = useState<CityItem[]>([]);
+  const [states, setStates] = useState<StateResponse[]>([]);
+  const [cities, setCities] = useState<CityResponse[]>([]);
 
   const [selectedStateName, setSelectedStateName] = useState('');
   const [selectedCityName, setSelectedCityName] = useState('');
@@ -45,7 +39,7 @@ export default function NewBranchPage() {
       const response = await api.state.findAll({
         page: 1,
         limit: 24,
-        countryId: '1238bc2a-45a5-47e4-9cc1-68d573089ca1',
+        countryId: COUNTRY_ID,
       });
 
       setStates(response.results);

--- a/src/app/(dashboard)/branches/page.tsx
+++ b/src/app/(dashboard)/branches/page.tsx
@@ -7,33 +7,13 @@ import { Column } from '@/components/Table';
 import { api } from '@/lib/sdkConfig';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
+import { BranchResponse, StateResponse } from '@pharmatech/sdk';
 
-interface BranchItem {
-  id: string;
-  name: string;
-  address: string;
-  city: {
-    id: string;
-    name: string;
-  };
-  latitude: number;
-  longitude: number;
-}
-
-interface BranchResponse {
-  results: BranchItem[];
-  count: number;
-  next: string | null;
-  previous: string | null;
-}
-
-interface StateItem {
-  id: string;
-  name: string;
-}
+/// This is a constant that represents the ID of Venezuela.
+const COUNTRY_ID = '1238bc2a-45a5-47e4-9cc1-68d573089ca1';
 
 export default function BranchesPage() {
-  const [branches, setBranches] = useState<BranchItem[]>([]);
+  const [branches, setBranches] = useState<BranchResponse[]>([]);
   const [states, setStates] = useState<string[]>(['Todos']);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -47,10 +27,7 @@ export default function BranchesPage() {
       try {
         if (!token) return;
 
-        const response: BranchResponse = await api.branch.findAll({
-          page,
-          limit,
-        });
+        const response = await api.branch.findAll({ page, limit });
         setBranches(response.results);
         setTotalItems(response.count);
       } catch (error) {
@@ -67,10 +44,11 @@ export default function BranchesPage() {
       const response = await api.state.findAll({
         page: 1,
         limit: 24,
-        countryId: '1238bc2a-45a5-47e4-9cc1-68d573089ca1',
+        countryId: COUNTRY_ID,
       });
 
-      const stateNames = response.results.map((state: StateItem) => state.name);
+      const statesList = response.results as StateResponse[];
+      const stateNames = statesList.map((state) => state.name);
       setStates(['Todos', ...stateNames]);
     } catch (error) {
       console.error('Error al obtener estados:', error);
@@ -86,7 +64,7 @@ export default function BranchesPage() {
 
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  const columns: Column<BranchItem>[] = [
+  const columns: Column<BranchResponse>[] = [
     {
       key: 'name',
       label: 'Nombre',
@@ -108,16 +86,16 @@ export default function BranchesPage() {
     router.push('/branches/new');
   };
 
-  const handleView = (item: BranchItem) => {
+  const handleView = (item: BranchResponse) => {
     router.push(`/branches/${item.id}`);
   };
 
-  const handleEdit = (item: BranchItem) => {
+  const handleEdit = (item: BranchResponse) => {
     router.push(`/branches/${item.id}/edit`);
   };
 
   return (
-    <div className="mx-auto my-12 max-h-[616px] max-w-[949px]">
+    <div className="mx-auto my-12">
       <div className="[&>ul]:max-h-60 [&>ul]:overflow-y-auto">
         <TableContainer
           title="Sucursales"

--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -7,36 +7,12 @@ import TableContainer from '@/components/TableContainer';
 import Dropdown from '@/components/Dropdown';
 import { Column } from '@/components/Table';
 import { api } from '@/lib/sdkConfig';
-
-interface Manufacturer {
-  id: string;
-  name: string;
-  description: string;
-  country: { name: string };
-}
-
-interface Category {
-  id: string;
-  name: string;
-  description: string;
-}
-
-export interface GenericProductResponse {
-  id: string;
-  name: string;
-  genericName: string;
-  description?: string;
-  priority: number;
-  manufacturer: Manufacturer;
-  categories: Category[];
-}
-
-type GenericProductItem = GenericProductResponse;
+import { CategoryResponse, GenericProductResponse } from '@pharmatech/sdk';
 
 export default function GenericProductListPage() {
-  const [products, setProducts] = useState<GenericProductItem[]>([]);
+  const [products, setProducts] = useState<GenericProductResponse[]>([]);
   const [filteredProducts, setFilteredProducts] = useState<
-    GenericProductItem[]
+    GenericProductResponse[]
   >([]);
   const [categories, setCategories] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -61,7 +37,7 @@ export default function GenericProductListPage() {
   const fetchCategories = useCallback(async () => {
     try {
       const resp = await api.category.findAll({ page: 1, limit: 20 });
-      const catNames = resp.results.map((cat: Category) => cat.name);
+      const catNames = resp.results.map((cat: CategoryResponse) => cat.name);
       setCategories(catNames);
     } catch (err) {
       console.error('Error al cargar categorías:', err);
@@ -94,7 +70,7 @@ export default function GenericProductListPage() {
 
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  const columns: Column<GenericProductItem>[] = [
+  const columns: Column<GenericProductResponse>[] = [
     {
       key: 'name',
       label: 'Nombre',
@@ -117,11 +93,11 @@ export default function GenericProductListPage() {
     },
   ];
 
-  const handleEdit = (item: GenericProductItem) => {
+  const handleEdit = (item: GenericProductResponse) => {
     router.push(`/products/${item.id}/edit`);
   };
 
-  const handleView = (item: GenericProductItem) => {
+  const handleView = (item: GenericProductResponse) => {
     router.push(`/products/${item.id}`);
   };
 

--- a/src/app/(dashboard)/users/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/users/[id]/edit/page.tsx
@@ -10,18 +10,7 @@ import { toast } from 'react-toastify';
 import { registerSchema } from '@/lib/validations/registerSchema';
 import { REDIRECTION_TIMEOUT } from '@/lib/utils/contants';
 import { useAuth } from '@/context/AuthContext';
-
-enum UserGender {
-  MALE = 'm',
-  FEMALE = 'f',
-}
-
-enum UserRole {
-  ADMIN = 'admin',
-  BRANCH_ADMIN = 'branch_admin',
-  CUSTOMER = 'customer',
-  DELIVERY = 'delivery',
-}
+import { UserGender, UserRole } from '@pharmatech/sdk';
 
 const roleLabels: Record<UserRole, string> = {
   [UserRole.ADMIN]: 'Administrador',

--- a/src/app/(dashboard)/users/[id]/page.tsx
+++ b/src/app/(dashboard)/users/[id]/page.tsx
@@ -12,54 +12,13 @@ import { ChevronRightIcon } from '@heroicons/react/24/solid';
 import { REDIRECTION_TIMEOUT } from '@/lib/utils/contants';
 import { useAuth } from '@/context/AuthContext';
 import Loading from '../../loading';
-
-enum UserRole {
-  ADMIN = 'admin',
-  BRANCH_ADMIN = 'branch_admin',
-  CUSTOMER = 'customer',
-  DELIVERY = 'delivery',
-}
+import { UserList, UserRole } from '@pharmatech/sdk';
 
 const roleLabels = {
   [UserRole.ADMIN]: 'Administrador',
   [UserRole.BRANCH_ADMIN]: 'Administrador de Sucursal',
   [UserRole.CUSTOMER]: 'Cliente',
   [UserRole.DELIVERY]: 'Repartidor',
-};
-
-type ApiUserResponse = {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  documentId: string;
-  phoneNumber: string;
-  role: string;
-  isValidated: boolean;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string | null;
-  lastOrderDate: Date | null;
-  profile: {
-    birthDate?: Date | string;
-    gender?: string;
-    profilePicture?: string;
-  };
-};
-
-type UserList = {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  documentId: string;
-  phoneNumber: string;
-  role: string;
-  profile: {
-    birthDate?: Date | string;
-    gender?: 'm' | 'f';
-    profilePicture?: string;
-  };
 };
 
 export default function UserDetailsPage() {
@@ -78,27 +37,8 @@ export default function UserDetailsPage() {
     }
 
     try {
-      const userData: ApiUserResponse = await api.user.getProfile(id, token);
-
-      const processedUser: UserList = {
-        id: userData.id,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        email: userData.email,
-        documentId: userData.documentId,
-        phoneNumber: userData.phoneNumber,
-        role: userData.role,
-        profile: {
-          birthDate: userData.profile?.birthDate,
-          gender:
-            userData.profile?.gender === 'm' || userData.profile?.gender === 'f'
-              ? userData.profile.gender
-              : undefined,
-          profilePicture: userData.profile?.profilePicture,
-        },
-      };
-
-      setUser(processedUser);
+      const userData = await api.user.getProfile(id, token);
+      setUser(userData);
       setError(null);
     } catch (err) {
       console.error('Error al cargar el usuario:', err);

--- a/src/app/(dashboard)/users/new/page.tsx
+++ b/src/app/(dashboard)/users/new/page.tsx
@@ -10,21 +10,9 @@ import RadioButton from '@/components/RadioButton';
 import { Colors } from '@/styles/styles';
 import { toast } from 'react-toastify';
 import { api } from '@/lib/sdkConfig';
-
 import { registerSchema } from '@/lib/validations/registerSchema';
 import { REDIRECTION_TIMEOUT } from '@/lib/utils/contants';
-
-enum UserGender {
-  MALE = 'm',
-  FEMALE = 'f',
-}
-
-enum UserRole {
-  ADMIN = 'admin',
-  BRANCH_ADMIN = 'branch_admin',
-  CUSTOMER = 'customer',
-  DELIVERY = 'delivery',
-}
+import { UserGender, UserRole } from '@pharmatech/sdk';
 
 // Mapeo para mostrar etiquetas en el dropdown y obtener el valor que espera la API
 const roleMapping: Record<string, UserRole> = {

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -7,25 +7,7 @@ import Dropdown from '@/components/Dropdown';
 import { Column } from '@/components/Table';
 import { api } from '@/lib/sdkConfig';
 import { useAuth } from '@/context/AuthContext';
-
-interface UserItem {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  documentId: string;
-  phoneNumber: string;
-  lastOrderDate: Date;
-  role: string;
-  isValidated: boolean;
-}
-
-interface UserResponse {
-  results: UserItem[];
-  count: number;
-  next: string | null;
-  previous: string | null;
-}
+import { Pagination, UserList } from '@pharmatech/sdk';
 
 const roleTranslations: Record<string, string> = {
   admin: 'Administrador',
@@ -45,7 +27,7 @@ export default function UsersPage() {
   const router = useRouter();
   const { token, user } = useAuth();
 
-  const [users, setUsers] = useState<UserItem[]>([]);
+  const [users, setUsers] = useState<UserList[]>([]);
   const roles = [
     'Todos',
     'Administrador',
@@ -62,7 +44,7 @@ export default function UsersPage() {
     async (page: number, limit: number) => {
       try {
         if (!token) return;
-        const response: UserResponse = await api.user.findAll(
+        const response: Pagination<UserList> = await api.user.findAll(
           { page, limit },
           token,
         );
@@ -87,7 +69,7 @@ export default function UsersPage() {
 
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  const columns: Column<UserItem>[] = [
+  const columns: Column<UserList>[] = [
     {
       key: 'firstName',
       label: 'Nombre',
@@ -127,11 +109,11 @@ export default function UsersPage() {
     router.push('/users/new');
   };
 
-  const handleView = (item: UserItem) => {
+  const handleView = (item: UserList) => {
     router.push(`/users/${item.id}`);
   };
 
-  const handleEdit = (item: UserItem) => {
+  const handleEdit = (item: UserList) => {
     router.push(`/users/${item.id}/edit`);
   };
 

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -7,20 +7,20 @@ import Dropdown from '@/components/Dropdown';
 import { Column } from '@/components/Table';
 import { api } from '@/lib/sdkConfig';
 import { useAuth } from '@/context/AuthContext';
-import { Pagination, UserList } from '@pharmatech/sdk';
+import { Pagination, UserList, UserRole } from '@pharmatech/sdk';
 
-const roleTranslations: Record<string, string> = {
-  admin: 'Administrador',
-  branch_admin: 'Administrador de Sucursal',
-  customer: 'Cliente',
-  delivery: 'Repartidor',
+const roleTranslations: Record<UserRole, string> = {
+  [UserRole.ADMIN]: 'Administrador',
+  [UserRole.BRANCH_ADMIN]: 'Administrador de Sucursal',
+  [UserRole.CUSTOMER]: 'Cliente',
+  [UserRole.DELIVERY]: 'Repartidor',
 };
 
-const roleReverse: Record<string, string> = {
-  Administrador: 'admin',
-  'Administrador de Sucursal': 'branch_admin',
-  Cliente: 'customer',
-  Repartidor: 'delivery',
+const roleReverse: Record<string, UserRole> = {
+  Administrador: UserRole.ADMIN,
+  'Administrador de Sucursal': UserRole.BRANCH_ADMIN,
+  Cliente: UserRole.CUSTOMER,
+  Repartidor: UserRole.DELIVERY,
 };
 
 export default function UsersPage() {
@@ -88,7 +88,7 @@ export default function UsersPage() {
     {
       key: 'role',
       label: 'Rol',
-      render: (item) => roleTranslations[item.role] || item.role,
+      render: (item) => roleTranslations[item.role as UserRole] || item.role,
     },
     {
       key: 'isValidated',


### PR DESCRIPTION
# Summary

## This PR updates the Users, Branches, Products, and Promos pages to:

- Use enums and types directly from `@pharmatech/sdk` to improve type safety.
- Remove duplicated types like `BranchResponse` and `ApiUserResponse`.
- Clean and simplify form handling, payload building, and validation processes.
- Maintain all existing UI and functionality without visual or behavioral changes.

## Changes

### Branches:
- List, Create, View (Delete), and Edit pages updated to use BranchStatus enum.
- Status mappings and filtering made type-safe.

### Users:
- List, Create, View (Delete), and Edit pages updated to use `UserRole` and `UserGender` from the SDK.
- Role and gender mappings improved using enums.

### Products:
- List page updated to use `GenericProductResponse` and `CategoryResponse`  from SDK.

### Promos
- No need for refactor.

## Improvements
- Centralized type usage from SDK across the platform.
- Cleaner code, fewer potential bugs, and easier maintenance.
- Stronger type-checking and payload validation.