### PR TITLE
Add DashboardPage with StatCard component and date filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-datepicker": "^8.2.1",
         "react-dom": "^19.0.0",
         "react-toastify": "^11.0.5",
+        "recharts": "^2.15.3",
         "socket.io-client": "^4.8.1",
         "uuid": "^11.1.0",
         "zod": "^3.24.2"
@@ -2387,6 +2388,60 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -3903,8 +3958,117 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4008,6 +4172,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4119,6 +4288,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4932,6 +5110,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -5626,6 +5812,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7569,6 +7763,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
@@ -7579,6 +7787,21 @@
       "peerDependencies": {
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {
@@ -7601,6 +7824,46 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8732,6 +8995,11 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9138,6 +9406,27 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-datepicker": "^8.2.1",
     "react-dom": "^19.0.0",
     "react-toastify": "^11.0.5",
+    "recharts": "^2.15.3",
     "socket.io-client": "^4.8.1",
     "uuid": "^11.1.0",
     "zod": "^3.24.2"

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -27,6 +27,7 @@ import Calendar from '@/components/Calendar';
 import Badge from '@/components/Badge';
 import { Colors, FontSizes } from '@/styles/styles';
 import { useRouter } from 'next/navigation';
+import { getCurrentMonthDates, getPreviousPeriod } from '@/lib/utils/DateUtils';
 
 export default function DashboardPage() {
   const { token, user } = useAuth();
@@ -44,32 +45,6 @@ export default function DashboardPage() {
   ];
 
   const COLORS = [Colors.secondaryLight, Colors.primary];
-
-  // Fechas
-  const getCurrentMonthDates = () => {
-    const now = new Date();
-    const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
-      .toISOString()
-      .split('T')[0];
-    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-      .toISOString()
-      .split('T')[0];
-    return { firstDay, lastDay };
-  };
-
-  const getPreviousPeriod = (start: string, end: string) => {
-    const startDate = new Date(start);
-    const endDate = new Date(end);
-
-    const diffInMs = endDate.getTime() - startDate.getTime();
-    const previousEnd = new Date(startDate.getTime() - 1);
-    const previousStart = new Date(previousEnd.getTime() - diffInMs);
-
-    return {
-      startDate: previousStart.toISOString().split('T')[0],
-      endDate: previousEnd.toISOString().split('T')[0],
-    };
-  };
 
   const { firstDay, lastDay } = getCurrentMonthDates();
   const [fromDate, setFromDate] = useState<string>(firstDay);

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -22,6 +22,10 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
 } from 'recharts';
 import Calendar from '@/components/Calendar';
 import Badge from '@/components/Badge';
@@ -276,6 +280,81 @@ export default function DashboardPage() {
               <Tooltip />
               <Legend />
             </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Comparación Total de Ventas */}
+        <div className="mx-auto w-full rounded-xl bg-white p-6 shadow-md">
+          <h2 className="my-4 text-center text-lg font-semibold">
+            Comparación de Ventas
+          </h2>
+          <ResponsiveContainer width="100%" height={250}>
+            <BarChart
+              data={
+                [
+                  {
+                    name: 'Actual',
+                    value: stats?.totalSales ?? 0,
+                  },
+                  {
+                    name: 'Anterior',
+                    value: prevStats?.totalSales ?? 0,
+                  },
+                ] as { name: string; value: number }[]
+              }
+            >
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="value">
+                {[stats?.totalSales ?? 0, prevStats?.totalSales ?? 0].map(
+                  (_, index) => (
+                    <Cell
+                      key={`bar-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ),
+                )}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Comparación Total de Clientes */}
+        <div className="mx-auto w-full rounded-xl bg-white p-6 shadow-md">
+          <h2 className="my-4 text-center text-lg font-semibold">
+            Comparación de Nuevos Clientes
+          </h2>
+          <ResponsiveContainer width="100%" height={250}>
+            <BarChart
+              data={[
+                {
+                  name: 'Actual',
+                  value: stats?.totalNewUsers ?? 0,
+                },
+                {
+                  name: 'Anterior',
+                  value: prevStats?.totalNewUsers ?? 0,
+                },
+              ]}
+            >
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="value">
+                {[stats?.totalSales ?? 0, prevStats?.totalSales ?? 0].map(
+                  (_, index) => (
+                    <Cell
+                      key={`bar-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ),
+                )}
+              </Bar>
+            </BarChart>
           </ResponsiveContainer>
         </div>
       </div>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -2,17 +2,8 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import StatCard from '@/components/StatCard';
-import TableContainer from '@/components/TableContainer';
-import Dropdown from '@/components/Dropdown';
 import { api } from '@/lib/sdkConfig';
-import {
-  DashboardResponse,
-  ReportQueryParams,
-  OrderResponse,
-  OrderStatus,
-  OrderType,
-  Pagination,
-} from '@pharmatech/sdk';
+import { DashboardResponse, ReportQueryParams } from '@pharmatech/sdk';
 import { useAuth } from '@/context/AuthContext';
 import { toast } from 'react-toastify';
 import {
@@ -28,14 +19,11 @@ import {
   YAxis,
 } from 'recharts';
 import Calendar from '@/components/Calendar';
-import Badge from '@/components/Badge';
 import { Colors, FontSizes } from '@/styles/styles';
-import { useRouter } from 'next/navigation';
 import { getCurrentMonthDates, getPreviousPeriod } from '@/lib/utils/DateUtils';
 
 export default function DashboardPage() {
   const { token, user } = useAuth();
-  const router = useRouter();
 
   const [stats, setStats] = useState<DashboardResponse | null>(null);
   const [prevStats, setPrevStats] = useState<DashboardResponse | null>(null);
@@ -76,84 +64,9 @@ export default function DashboardPage() {
     }
   }, [token, fromDate, toDate]);
 
-  // Tabla de órdenes
-  const [orders, setOrders] = useState<OrderResponse[]>([]);
-  const [query, setQuery] = useState<string>(''); // Búsqueda
-  const [selectedStatus, setSelectedStatus] = useState<OrderStatus | ''>(''); // Filtro de estado
-  const [selectedType, setSelectedType] = useState<OrderType | ''>(''); // Filtro de tipo
-  const [page, setPage] = useState<number>(1);
-  const [limit, setLimit] = useState<number>(10);
-  const [total, setTotal] = useState<number>(0);
-
-  const statusOptions = [
-    { value: '', label: 'Todos' },
-    { value: OrderStatus.REQUESTED, label: 'Solicitado' },
-    { value: OrderStatus.IN_PROGRESS, label: 'En proceso' },
-    { value: OrderStatus.APPROVED, label: 'Aprobada' },
-    { value: OrderStatus.CANCELED, label: 'Cancelada' },
-    { value: OrderStatus.READY_FOR_PICKUP, label: 'Lista para Retiro' },
-    { value: OrderStatus.COMPLETED, label: 'Completado' },
-  ];
-
-  const typeOptions = [
-    { value: '', label: 'Todos' },
-    { value: OrderType.PICKUP, label: 'Pickup' },
-    { value: OrderType.DELIVERY, label: 'Delivery' },
-  ];
-
-  const fetchOrders = useCallback(async () => {
-    if (!token) return;
-
-    try {
-      const params: Parameters<typeof api.order.findAll>[0] = {
-        page,
-        limit,
-        ...(query ? { q: query } : {}),
-        ...(selectedStatus ? { status: selectedStatus } : {}),
-        ...(selectedType ? { type: selectedType } : {}),
-      };
-
-      const resp: Pagination<OrderResponse> = await api.order.findAll(
-        params,
-        token,
-      );
-      setOrders(resp.results);
-      setTotal(resp.count);
-    } catch (error) {
-      console.error('Error fetching orders:', error);
-      toast.error('Error al cargar órdenes');
-    } finally {
-    }
-  }, [token, page, limit, query, selectedStatus, selectedType]);
-
   useEffect(() => {
     fetchDashboardStats();
-    fetchOrders();
-  }, [fetchDashboardStats, fetchOrders]);
-
-  const columns = [
-    { key: 'id', label: 'ID', render: (o: OrderResponse) => o.id.slice(0, 8) },
-    {
-      key: 'createdAt',
-      label: 'Creación',
-      render: (o: OrderResponse) => new Date(o.createdAt).toLocaleDateString(),
-    },
-    {
-      key: 'status',
-      label: 'Estado',
-      render: (o: OrderResponse) => (
-        <Badge variant="filled" color="info" size="medium">
-          {o.status}
-        </Badge>
-      ),
-    },
-    { key: 'type', label: 'Tipo', render: (o: OrderResponse) => o.type },
-    {
-      key: 'totalPrice',
-      label: 'Precio Total',
-      render: (o: OrderResponse) => `$${o.totalPrice.toFixed(2)}`,
-    },
-  ];
+  }, [fetchDashboardStats]);
 
   return (
     <div className="mx-auto max-w-full space-y-6 p-6">
@@ -358,59 +271,6 @@ export default function DashboardPage() {
           </ResponsiveContainer>
         </div>
       </div>
-      {/* Tabla de órdenes */}
-      <TableContainer<OrderResponse>
-        title="Órdenes"
-        tableData={orders}
-        tableColumns={columns}
-        onView={(o) => router.push(`/orders/${o.id}`)}
-        onEdit={(o) => router.push(`/orders/${o.id}/edit`)}
-        onSearch={(searchTerm) => setQuery(searchTerm)}
-        addButtonText="Ir al listado de órdenes"
-        onAddClick={() => router.push('/orders/')}
-        dropdownComponent={
-          <div className="flex space-x-2">
-            <Dropdown
-              title="Estado"
-              items={statusOptions.map((o) => o.label)}
-              onChange={(label) => {
-                const opt = statusOptions.find((o) => o.label === label);
-                setSelectedStatus((opt?.value as OrderStatus) ?? '');
-                setPage(1);
-              }}
-              selected={
-                statusOptions.find((o) => o.value === selectedStatus)?.label ||
-                'Todos'
-              }
-            />
-            <Dropdown
-              title="Tipo"
-              items={typeOptions.map((o) => o.label)}
-              onChange={(label) => {
-                const opt = typeOptions.find((o) => o.label === label);
-                setSelectedType((opt?.value as OrderType) ?? '');
-                setPage(1);
-              }}
-              selected={
-                typeOptions.find((o) => o.value === selectedType)?.label ||
-                'Todos'
-              }
-            />
-          </div>
-        }
-        pagination={{
-          currentPage: page,
-          totalPages: Math.ceil(total / limit),
-          totalItems: total,
-          itemsPerPage: limit,
-          onPageChange: setPage,
-          onItemsPerPageChange: (val) => {
-            setLimit(val);
-            setPage(1);
-          },
-          itemsPerPageOptions: [5, 10, 15, 20],
-        }}
-      />
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import StatCard from '@/components/StatCard';
+import TableContainer from '@/components/TableContainer';
+import Dropdown from '@/components/Dropdown';
+import { api } from '@/lib/sdkConfig';
+import {
+  DashboardResponse,
+  ReportQueryParams,
+  OrderResponse,
+  OrderStatus,
+  OrderType,
+  Pagination,
+} from '@pharmatech/sdk';
+import { useAuth } from '@/context/AuthContext';
+import { toast } from 'react-toastify';
+import Calendar from '@/components/Calendar';
+import Button from '@/components/Button';
+import Badge from '@/components/Badge';
+import { Colors, FontSizes } from '@/styles/styles';
+import { useRouter } from 'next/navigation';
+
+export default function DashboardPage() {
+  const { token, user } = useAuth();
+  const router = useRouter();
+
+  const [stats, setStats] = useState<DashboardResponse | null>(null);
+
+  // Fechas
+  const getCurrentMonthDates = () => {
+    const now = new Date();
+    const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toISOString()
+      .split('T')[0];
+    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+      .toISOString()
+      .split('T')[0];
+    return { firstDay, lastDay };
+  };
+
+  const { firstDay, lastDay } = getCurrentMonthDates();
+  const [fromDate, setFromDate] = useState<string>(firstDay);
+  const [toDate, setToDate] = useState<string>(lastDay);
+
+  const fetchDashboardStats = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const params: ReportQueryParams = {
+        startDate: fromDate || '',
+        endDate: toDate || '',
+      };
+
+      const response = await api.report.getDashboard(params, token);
+      setStats(response);
+    } catch (error) {
+      console.error('Error fetching dashboard stats:', error);
+      toast.error('Error al cargar el resumen del dashboard');
+    } finally {
+    }
+  }, [token, fromDate, toDate]);
+
+  // Tabla de órdenes
+  const [orders, setOrders] = useState<OrderResponse[]>([]);
+  const [query, setQuery] = useState<string>(''); // Búsqueda
+  const [selectedStatus, setSelectedStatus] = useState<OrderStatus | ''>(''); // Filtro de estado
+  const [selectedType, setSelectedType] = useState<OrderType | ''>(''); // Filtro de tipo
+  const [page, setPage] = useState<number>(1);
+  const [limit, setLimit] = useState<number>(10);
+  const [total, setTotal] = useState<number>(0);
+
+  const statusOptions = [
+    { value: '', label: 'Todos' },
+    { value: OrderStatus.REQUESTED, label: 'Solicitado' },
+    { value: OrderStatus.IN_PROGRESS, label: 'En proceso' },
+    { value: OrderStatus.APPROVED, label: 'Aprobada' },
+    { value: OrderStatus.CANCELED, label: 'Cancelada' },
+    { value: OrderStatus.READY_FOR_PICKUP, label: 'Lista para Retiro' },
+    { value: OrderStatus.COMPLETED, label: 'Completado' },
+  ];
+
+  const typeOptions = [
+    { value: '', label: 'Todos' },
+    { value: OrderType.PICKUP, label: 'Pickup' },
+    { value: OrderType.DELIVERY, label: 'Delivery' },
+  ];
+
+  const fetchOrders = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const params: Parameters<typeof api.order.findAll>[0] = {
+        page,
+        limit,
+        ...(query ? { q: query } : {}),
+        ...(selectedStatus ? { status: selectedStatus } : {}),
+        ...(selectedType ? { type: selectedType } : {}),
+      };
+
+      const resp: Pagination<OrderResponse> = await api.order.findAll(
+        params,
+        token,
+      );
+      setOrders(resp.results);
+      setTotal(resp.count);
+    } catch (error) {
+      console.error('Error fetching orders:', error);
+      toast.error('Error al cargar órdenes');
+    } finally {
+    }
+  }, [token, page, limit, query, selectedStatus, selectedType]);
+
+  useEffect(() => {
+    fetchDashboardStats();
+    fetchOrders();
+  }, [fetchDashboardStats, fetchOrders]);
+
+  const columns = [
+    { key: 'id', label: 'ID', render: (o: OrderResponse) => o.id.slice(0, 8) },
+    {
+      key: 'createdAt',
+      label: 'Creación',
+      render: (o: OrderResponse) => new Date(o.createdAt).toLocaleDateString(),
+    },
+    {
+      key: 'status',
+      label: 'Estado',
+      render: (o: OrderResponse) => (
+        <Badge variant="filled" color="info" size="medium">
+          {o.status}
+        </Badge>
+      ),
+    },
+    { key: 'type', label: 'Tipo', render: (o: OrderResponse) => o.type },
+    {
+      key: 'totalPrice',
+      label: 'Precio Total',
+      render: (o: OrderResponse) => `$${o.totalPrice.toFixed(2)}`,
+    },
+  ];
+
+  return (
+    <div className="mx-auto max-w-full space-y-6 p-6">
+      <h1
+        className="text-2xl font-semibold"
+        style={{
+          color: Colors.textMain,
+          fontSize: FontSizes.h2.size,
+          lineHeight: `${FontSizes.h2.lineHeight}px`,
+        }}
+      >
+        ¡Bienvenido, {user?.name || 'Usuario'}!
+      </h1>
+
+      {/* Filtros de fechas */}
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label className="mb-1 block text-sm text-gray-700">Desde:</label>
+          <Calendar
+            initialDate={fromDate}
+            onDateSelect={(date) => setFromDate(date)}
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm text-gray-700">Hasta:</label>
+          <Calendar
+            initialDate={toDate}
+            onDateSelect={(date) => setToDate(date)}
+          />
+        </div>
+        <Button
+          onClick={fetchDashboardStats}
+          color={Colors.primary}
+          textColor={Colors.textWhite}
+          paddingX={4}
+          paddingY={2}
+          textSize="base"
+          width="auto"
+          height="42px"
+          className="self-end"
+        >
+          Filtrar
+        </Button>
+      </div>
+
+      {/* Estadísticas */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <StatCard title="Órdenes Activas" value={stats?.openOrders ?? 0} />
+        <StatCard
+          title="Órdenes Completadas"
+          value={stats?.completedOrders ?? 0}
+        />
+        <StatCard
+          title="Total de Nuevos Clientes"
+          value={stats?.totalNewUsers ?? 0}
+        />
+        <StatCard title="Total de Ventas" value={stats?.totalSales ?? 0} />
+      </div>
+
+      {/* Tabla de órdenes */}
+      <TableContainer<OrderResponse>
+        title="Órdenes"
+        tableData={orders}
+        tableColumns={columns}
+        onView={(o) => router.push(`/orders/${o.id}`)}
+        onEdit={(o) => router.push(`/orders/${o.id}/edit`)}
+        onSearch={(searchTerm) => setQuery(searchTerm)}
+        addButtonText="Ir al listado de órdenes"
+        onAddClick={() => router.push('/orders/')}
+        dropdownComponent={
+          <div className="flex space-x-2">
+            <Dropdown
+              title="Estado"
+              items={statusOptions.map((o) => o.label)}
+              onChange={(label) => {
+                const opt = statusOptions.find((o) => o.label === label);
+                setSelectedStatus((opt?.value as OrderStatus) ?? '');
+                setPage(1);
+              }}
+              selected={
+                statusOptions.find((o) => o.value === selectedStatus)?.label ||
+                'Todos'
+              }
+            />
+            <Dropdown
+              title="Tipo"
+              items={typeOptions.map((o) => o.label)}
+              onChange={(label) => {
+                const opt = typeOptions.find((o) => o.label === label);
+                setSelectedType((opt?.value as OrderType) ?? '');
+                setPage(1);
+              }}
+              selected={
+                typeOptions.find((o) => o.value === selectedType)?.label ||
+                'Todos'
+              }
+            />
+          </div>
+        }
+        pagination={{
+          currentPage: page,
+          totalPages: Math.ceil(total / limit),
+          totalItems: total,
+          itemsPerPage: limit,
+          onPageChange: setPage,
+          onItemsPerPageChange: (val) => {
+            setLimit(val);
+            setPage(1);
+          },
+          itemsPerPageOptions: [5, 10, 15, 20],
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -15,6 +15,14 @@ import {
 } from '@pharmatech/sdk';
 import { useAuth } from '@/context/AuthContext';
 import { toast } from 'react-toastify';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 import Calendar from '@/components/Calendar';
 import Button from '@/components/Button';
 import Badge from '@/components/Badge';
@@ -26,6 +34,16 @@ export default function DashboardPage() {
   const router = useRouter();
 
   const [stats, setStats] = useState<DashboardResponse | null>(null);
+
+  const pieData = [
+    { name: 'Órdenes Abiertas', value: stats?.openOrders ?? 0 },
+    {
+      name: 'Órdenes Completadas',
+      value: stats?.completedOrders ?? 0,
+    },
+  ];
+
+  const COLORS = [Colors.secondaryLight, Colors.primary];
 
   // Fechas
   const getCurrentMonthDates = () => {
@@ -196,6 +214,31 @@ export default function DashboardPage() {
           value={stats?.totalNewUsers ?? 0}
         />
         <StatCard title="Total de Ventas" value={stats?.totalSales ?? 0} />
+      </div>
+      <div className="mx-auto w-full rounded-xl bg-white p-6 shadow-md">
+        <h2 className="my-4 text-center text-lg font-semibold">
+          Distribución de Órdenes Abiertas
+        </h2>
+        <ResponsiveContainer width="100%" height={250}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              dataKey="value"
+              nameKey="name"
+              outerRadius={100}
+              label
+            >
+              {pieData.map((_, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={COLORS[index % COLORS.length]}
+                />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
       </div>
 
       {/* Tabla de órdenes */}

--- a/src/app/(dashboard)/orders/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/orders/[id]/edit/page.tsx
@@ -72,7 +72,7 @@ export default function EditOrderStatusPage() {
     return () => {
       socket.disconnect();
     };
-  }, []);
+  }, [isConnected, socket]);
 
   const fetchOrderData = useCallback(async () => {
     if (!token || !id) return;

--- a/src/app/(dashboard)/reports/sales/page.tsx
+++ b/src/app/(dashboard)/reports/sales/page.tsx
@@ -89,7 +89,7 @@ export default function ReportPreviewPage() {
         console.error('Error al obtener sucursales:', err);
       }
     })();
-  }, [selectedCity, token]);
+  }, [selectedCity, token, selectedState]);
 
   const params: ReportQueryParams = useMemo(() => {
     return { startDate, endDate, branchId };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -15,7 +15,7 @@ export default function LoginPage() {
   // 🔐 Si ya está autenticado, redirige (previene acceso al login)
   useEffect(() => {
     if (!loading && token && user) {
-      router.replace('/products');
+      router.replace('/dashboard');
     }
   }, [token, user, loading, router]);
 

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -5,16 +5,41 @@ import { Colors } from '@/styles/styles';
 
 interface StatCardProps {
   title: string;
-  value: number | string;
+  value: number;
+  previousValue?: number;
+  prefix?: string;
 }
 
-const StatCard: React.FC<StatCardProps> = ({ title, value }) => {
+const StatCard: React.FC<StatCardProps> = ({
+  title,
+  value,
+  previousValue,
+  prefix,
+}) => {
+  const diff = previousValue !== undefined ? value - previousValue : null;
+  const diffText =
+    diff !== null
+      ? `${diff > 0 ? '+' : ''}${diff} respecto al periodo anterior`
+      : null;
+
+  const diffColor =
+    diff !== null
+      ? diff > 0
+        ? Colors.semanticSuccess
+        : Colors.semanticDanger
+      : Colors.textMain;
+
   return (
     <div className="w-full rounded-xl bg-white p-6 shadow-md">
       <p className="text-sm text-gray-500">{title}</p>
       <h2 className="mt-2 text-2xl font-bold" style={{ color: Colors.primary }}>
-        {value}
+        {prefix} {value}
       </h2>
+      {diffText && (
+        <p className="mt-1 text-sm" style={{ color: diffColor }}>
+          {diffText}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { Colors } from '@/styles/styles';
+
+interface StatCardProps {
+  title: string;
+  value: number | string;
+}
+
+const StatCard: React.FC<StatCardProps> = ({ title, value }) => {
+  return (
+    <div className="w-full rounded-xl bg-white p-6 shadow-md">
+      <p className="text-sm text-gray-500">{title}</p>
+      <h2 className="mt-2 text-2xl font-bold" style={{ color: Colors.primary }}>
+        {value}
+      </h2>
+    </div>
+  );
+};
+
+export default StatCard;

--- a/src/lib/utils/DateUtils.ts
+++ b/src/lib/utils/DateUtils.ts
@@ -14,3 +14,36 @@ export const MONTH_NAMES = [
 ];
 
 export const WEEK_DAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+
+// utils/dateUtils.ts
+
+export function getCurrentMonthDates(): { firstDay: string; lastDay: string } {
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split('T')[0];
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .split('T')[0];
+  return { firstDay, lastDay };
+}
+
+export function getPreviousPeriod(
+  start: string,
+  end: string,
+): {
+  startDate: string;
+  endDate: string;
+} {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+
+  const diffInMs = endDate.getTime() - startDate.getTime();
+  const previousEnd = new Date(startDate.getTime() - 1);
+  const previousStart = new Date(previousEnd.getTime() - diffInMs);
+
+  return {
+    startDate: previousStart.toISOString().split('T')[0],
+    endDate: previousEnd.toISOString().split('T')[0],
+  };
+}


### PR DESCRIPTION
This pull request introduces the new DashboardPage, which displays key metrics using the newly created StatCard component. It fetches data from the report.getDashboard endpoint using the current month's date range by default and includes date range filters (startDate and endDate) to update the dashboard stats dynamically. This implementation enhances visibility into operational data and provides a more interactive and informative overview of the platform’s performance. Also, there are graph like pie chart and bar chart from recharts that are used to show the comparison between current and prev period