### PR TITLE
Standardize validation schemas

### DIFF
--- a/src/app/(dashboard)/users/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/users/[id]/edit/page.tsx
@@ -90,25 +90,25 @@ export default function EditUserPage() {
     const genero = gender === UserGender.MALE ? 'hombre' : 'mujer';
 
     const result = registerSchema.safeParse({
-      nombre: firstName,
-      apellido: lastName,
+      firstName: firstName,
+      lastName: lastName,
       email,
-      cedula: documentId,
-      telefono: phoneNumber,
-      fechaNacimiento: birthDate ? convertSlashDateToIso(birthDate) : null,
-      genero,
+      documentId: documentId,
+      phoneNumber: phoneNumber,
+      birthDate: birthDate ? convertSlashDateToIso(birthDate) : null,
+      gender: genero,
     });
 
     if (!result.success) {
       const fieldErrors = result.error.flatten().fieldErrors;
       setErrors({
-        firstName: fieldErrors.nombre?.[0] || '',
-        lastName: fieldErrors.apellido?.[0] || '',
+        firstName: fieldErrors.firstName?.[0] || '',
+        lastName: fieldErrors.lastName?.[0] || '',
         email: fieldErrors.email?.[0] || '',
-        documentId: fieldErrors.cedula?.[0] || '',
-        phoneNumber: fieldErrors.telefono?.[0] || '',
-        birthDate: fieldErrors.fechaNacimiento?.[0] || '',
-        gender: fieldErrors.genero?.[0] || '',
+        documentId: fieldErrors.documentId?.[0] || '',
+        phoneNumber: fieldErrors.phoneNumber?.[0] || '',
+        birthDate: fieldErrors.birthDate?.[0] || '',
+        gender: fieldErrors.gender?.[0] || '',
       });
       toast.error('Por favor, revisa los errores en el formulario');
       return;

--- a/src/app/(dashboard)/users/new/page.tsx
+++ b/src/app/(dashboard)/users/new/page.tsx
@@ -81,25 +81,25 @@ export default function NewUserPage() {
 
     // Prepara los datos para la validación usando el schema
     const result = registerSchema.safeParse({
-      nombre: firstName,
-      apellido: lastName,
+      firstName: firstName,
+      lastName: lastName,
       email,
-      cedula: documentId,
-      telefono: phoneNumber,
-      fechaNacimiento: convertSlashDateToIso(birthDate), // Se espera formato yyyy-mm-dd
-      genero,
+      documentId: documentId,
+      phoneNumber: phoneNumber,
+      birthDate: convertSlashDateToIso(birthDate), // Se espera formato yyyy-mm-dd
+      gender: genero,
     });
 
     if (!result.success) {
       const { fieldErrors } = result.error.flatten();
       setErrors({
-        firstName: fieldErrors.nombre?.[0] || '',
-        lastName: fieldErrors.apellido?.[0] || '',
+        firstName: fieldErrors.firstName?.[0] || '',
+        lastName: fieldErrors.lastName?.[0] || '',
         email: fieldErrors.email?.[0] || '',
-        documentId: fieldErrors.cedula?.[0] || '',
-        phoneNumber: fieldErrors.telefono?.[0] || '',
-        birthDate: fieldErrors.fechaNacimiento?.[0] || '',
-        gender: fieldErrors.genero?.[0] || '',
+        documentId: fieldErrors.documentId?.[0] || '',
+        phoneNumber: fieldErrors.phoneNumber?.[0] || '',
+        birthDate: fieldErrors.birthDate?.[0] || '',
+        gender: fieldErrors.gender?.[0] || '',
       });
       toast.error('Por favor, revisa los errores en el formulario');
       return;

--- a/src/lib/validations/categorySchema.ts
+++ b/src/lib/validations/categorySchema.ts
@@ -8,7 +8,7 @@ export const categorySchema = z.object({
   description: z
     .string()
     .min(1, 'La descripción es requerida')
-    .max(255, 'La descripción no puede exceder 500 caracteres'),
+    .max(255, 'La descripción no puede exceder 255 caracteres'),
 });
 
 export type CategoryFormValues = z.infer<typeof categorySchema>;

--- a/src/lib/validations/editProfileSchema.ts
+++ b/src/lib/validations/editProfileSchema.ts
@@ -24,8 +24,8 @@ export const editProfileSchema = z
       .string()
       .optional()
       .refine(
-        (value) => value === undefined || /^\+\d{8,15}$/.test(value),
-        'El teléfono debe iniciar con + y tener entre 8 y 15 dígitos',
+        (value) => value === undefined || /^\d{8,15}$/.test(value),
+        'El teléfono debe tener entre 8 y 15 dígitos numéricos',
       ),
     birthDate: z
       .string()

--- a/src/lib/validations/loginSchema.ts
+++ b/src/lib/validations/loginSchema.ts
@@ -8,5 +8,6 @@ export const loginSchema = z.object({
   password: z
     .string()
     .nonempty('La contraseña es obligatoria')
-    .min(6, 'La contraseña debe tener al menos 6 caracteres'),
+    .min(6, 'La contraseña debe tener al menos 6 caracteres')
+    .max(255, 'La contraseña no puede exceder los 255 caracteres'),
 });

--- a/src/lib/validations/loginSchema.ts
+++ b/src/lib/validations/loginSchema.ts
@@ -8,6 +8,6 @@ export const loginSchema = z.object({
   password: z
     .string()
     .nonempty('La contraseña es obligatoria')
-    .min(6, 'La contraseña debe tener al menos 6 caracteres')
+    .min(8, 'La contraseña debe tener al menos 8 caracteres')
     .max(255, 'La contraseña no puede exceder los 255 caracteres'),
 });

--- a/src/lib/validations/newPresentationSchema.ts
+++ b/src/lib/validations/newPresentationSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const newPresentationSchema = z.object({
   name: z.string().min(1, 'El nombre de la presentación es requerido'),
-  description: z.string().optional(), // o .min(1, 'Descripción requerida') si es obligatoria
+  description: z.string().min(1, 'Descripción requerida'),
   quantity: z
     .string()
     .min(1, 'La cantidad es requerida')

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -2,27 +2,27 @@ import { z } from 'zod';
 
 export const registerSchema = z
   .object({
-    nombre: z
+    firstName: z
       .string()
+      .nonempty('El nombre es obligatorio')
       .min(2, 'El nombre debe tener al menos 2 caracteres')
       .max(50, 'El nombre no puede exceder los 50 caracteres')
-      .regex(/^[a-zA-Z\s]+$/, 'El nombre solo puede contener letras')
-      .nonempty('El nombre es obligatorio'),
-    apellido: z
+      .regex(/^[a-zA-Z\s]+$/, 'El nombre solo puede contener letras'),
+    lastName: z
       .string()
+      .nonempty('El apellido es obligatorio')
       .min(2, 'El apellido debe tener al menos 2 caracteres')
       .max(50, 'El apellido no puede exceder los 50 caracteres')
-      .regex(/^[a-zA-Z\s]+$/, 'El apellido solo puede contener letras')
-      .nonempty('El apellido es obligatorio'),
+      .regex(/^[a-zA-Z\s]+$/, 'El apellido solo puede contener letras'),
     email: z
       .string()
       .nonempty('El email es obligatorio')
       .email('Formato de email inválido'),
-    cedula: z
+    documentId: z
       .string()
       .nonempty('La cédula es obligatoria')
       .regex(/^\d+$/, 'La cédula debe contener solo números'),
-    telefono: z
+    phoneNumber: z
       .string()
       .transform((value) => (value?.trim() === '' ? null : value))
       .nullable()
@@ -30,7 +30,7 @@ export const registerSchema = z
         (value) => value === null || /^\d{8,15}$/.test(value),
         'El teléfono debe tener entre 8 y 15 dígitos numéricos',
       ),
-    fechaNacimiento: z
+    birthDate: z
       .string()
       .nonempty('La fecha de nacimiento es obligatoria')
       .regex(
@@ -54,7 +54,7 @@ export const registerSchema = z
           message: 'Debes tener al menos 14 años',
         },
       ),
-    genero: z
+    gender: z
       .string()
       .transform((value) => (value?.trim() === '' ? null : value))
       .nullable()
@@ -67,12 +67,13 @@ export const registerSchema = z
     password: z
       .string()
       .min(8, 'La contraseña debe tener al menos 8 caracteres')
-      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-      .regex(/\d/, 'Debe tener al menos un número')
-      .regex(/[!@#$%^&*]/, 'Debe tener al menos un símbolo especial (!@#$%^&*)')
+      .max(255, 'La contraseña no puede exceder los 255 caracteres')
       .optional(),
-    confirmPassword: z.string().optional(),
+    confirmPassword: z
+      .string()
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder los 255 caracteres')
+      .optional(),
   })
   .refine(
     (data) => {

--- a/src/lib/validations/registerSchema.ts
+++ b/src/lib/validations/registerSchema.ts
@@ -27,8 +27,8 @@ export const registerSchema = z
       .transform((value) => (value?.trim() === '' ? null : value))
       .nullable()
       .refine(
-        (value) => value === null || /^\+\d{8,15}$/.test(value),
-        'El teléfono debe iniciar con + y tener entre 8 y 15 dígitos',
+        (value) => value === null || /^\d{8,15}$/.test(value),
+        'El teléfono debe tener entre 8 y 15 dígitos numéricos',
       ),
     fechaNacimiento: z
       .string()

--- a/src/lib/validations/updatePasswordSchema.ts
+++ b/src/lib/validations/updatePasswordSchema.ts
@@ -2,22 +2,23 @@ import { z } from 'zod';
 
 export const updatePasswordSchema = z
   .object({
-    password: z.string().nonempty('La contraseña actual es obligatoria'),
+    password: z
+      .string()
+      .nonempty('La contraseña actual es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
+
     newPassword: z
       .string()
       .nonempty('La contraseña es obligatoria')
       .min(8, 'La contraseña debe tener al menos 8 caracteres')
-      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-      .regex(/\d/, 'Debe tener al menos un número')
-      .regex(
-        /[!@#$%^&*]/,
-        'Debe tener al menos un símbolo especial (!@#$%^&*)',
-      ),
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
 
     confirmPassword: z
       .string()
-      .nonempty('La confirmación de contraseña es obligatoria'),
+      .nonempty('La confirmación de contraseña es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
+      .max(255, 'La contraseña no puede exceder 255 caracteres'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'Las contraseñas no coinciden',

--- a/src/lib/validations/updatePasswordSchema.ts
+++ b/src/lib/validations/updatePasswordSchema.ts
@@ -2,22 +2,21 @@ import { z } from 'zod';
 
 export const updatePasswordSchema = z
   .object({
-    password: z.string().nonempty('La contraseña es obligatoria'),
+    password: z.string().nonempty('La contraseña actual es obligatoria'),
     newPassword: z
       .string()
-      .min(8, 'La confirmación debe tener al menos 8 caracteres')
+      .nonempty('La contraseña es obligatoria')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres')
       .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
       .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
       .regex(/\d/, 'Debe tener al menos un número')
-      .regex(/[!@#$%^&*]/, 'Debe tener al menos un símbolo especial (!@#$%^&*)')
-      .nonempty('La confirmación de contraseña es obligatoria'),
+      .regex(
+        /[!@#$%^&*]/,
+        'Debe tener al menos un símbolo especial (!@#$%^&*)',
+      ),
+
     confirmPassword: z
       .string()
-      .min(8, 'La confirmación debe tener al menos 8 caracteres')
-      .regex(/[A-Z]/, 'Debe tener al menos una letra mayúscula')
-      .regex(/[a-z]/, 'Debe tener al menos una letra minúscula')
-      .regex(/\d/, 'Debe tener al menos un número')
-      .regex(/[!@#$%^&*]/, 'Debe tener al menos un símbolo especial (!@#$%^&*)')
       .nonempty('La confirmación de contraseña es obligatoria'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {


### PR DESCRIPTION
# 📦 Standardize validation schemas (Dashboard)

## ✅ Summary

This PR standardizes the validation logic across multiple schemas to improve consistency and maintainability in the **dashboard module**.

---

## 🔐 Password Validation (Min/Max Length Only)

All password-related inputs (`password`, `newPassword`, `confirmPassword`) now share a consistent validation rule:

- **Minimum:** 8 characters  
- **Maximum:** 255 characters

This change applies to the following schemas:

- `registerSchema`
- `updatePasswordSchema`
- `loginSchema`

---

## 📞 Phone Number Validation Update

Phone number inputs **no longer require a `+` sign**.  
They now only validate that the input contains **8 to 15 numeric digits**.

This change applies to:

- `registerSchema`
- `editProfileSchema`

---

## 🏷️ Schema Field Key Updates

The following schema has been updated to rename field keys from Spanish to English for consistency:

- `registerSchema`
  - `nombre` → `firstName`
  - `apellido` → `lastName`
  - `cedula` → `documentId`
  - `telefono` → `phoneNumber`
  - `fechaNacimiento` → `birthDate`
  - `genero` → `gender`

As a result, the following pages were updated accordingly to align with the schema:

- `src/app/(dashboard)/users/new/page.tsx`
- `src/app/(dashboard)/users/[id]/edit/page.tsx`

---

## 📂 Modified Schemas

- `categorySchema.ts`
- `editProfileSchema.ts`
- `loginSchema.ts`
- `newPresentationSchema.ts`
- `registerSchema.ts`
- `updatePasswordSchema.ts`

✅ No changes were necessary for the remaining schemas.

---

Let me know if you'd like this split into separate commits or PRs.
